### PR TITLE
feat: add synth HAPI stack and analytics pipeline to compose

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -71,6 +71,26 @@ KEYCLOAK_PORT=8081
 HAPI_FHIR_PORT=8082
 FHIR_GATEWAY_PORT=8083
 
+# --- Synth stack ports (profile: --synth / --pipes) --------------------------
+# Isolated HAPI FHIR + PostgreSQL for synthetic/test data.
+POSTGRES_SYNTH_PORT=5435
+HAPI_SYNTH_PORT=8085
+
+# --- Analytics pipeline ports (profile: --pipes) -----------------------------
+POSTGRES_ANALYTICS_PORT=5434
+PIPELINE_PORT=8090
+SUPERSET_PORT=8088
+
+# Superset encryption key (required — set any long random string)
+SUPERSET_SECRET_KEY=[generated]
+
+# FHIR server the pipeline reads from.
+# Switch to http://hapi-fhir:8080/fhir once transactional data is ready.
+PIPELINE_FHIR_SOURCE=http://hapi-synth:8080/fhir
+
+# JVM heap for the pipeline controller (tune to ~50% of Docker memory limit)
+PIPELINE_JAVA_OPTS=-Xms512m -Xmx4g
+
 # --- Auth mode ---------------------------------------------------------------
 # Controls which HAPI FHIR config file is mounted into the container
 #   application-no-auth.yaml  — HAPI FHIR runs open, no token validation

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 # Ignore active containers/data if mapped to the project root
 data/
 db_data/
+data-pipes/dwh/*/
 *.tar
 *.tar.gz
 
@@ -32,6 +33,7 @@ secrets/
 keycloak/ohs-player-realm.json
 hapi-fhir/application-no-auth.yaml
 hapi-fhir/application-auth.yaml
+data-pipes/config/postgres-analytics.json
 
 # --- Logs & Temps ---
 logs/

--- a/data-pipes/config/application.yaml
+++ b/data-pipes/config/application.yaml
@@ -1,0 +1,35 @@
+fhirdata:
+  fhirFetchMode: "FHIR_SEARCH"
+  # Source overridden at runtime via FHIRDATA_FHIRSERVERURL env var in compose.
+  # Default: hapi-synth. Switch to hapi-fhir for transactional data.
+  fhirServerUrl: "http://hapi-synth:8080/fhir"
+
+  dwhRootPrefix: "/dwh/controller_DWH"
+  generateParquetFiles: true
+
+  # Nightly incremental sync at midnight; purge old snapshots at 00:30
+  incrementalSchedule: "0 0 * * * *"
+  purgeSchedule: "0 30 * * * *"
+  numOfDwhSnapshotsToRetain: 2
+
+  # OHS 12-resource scope
+  resourceList: "Patient,Practitioner,Location,Group,RelatedPerson,Encounter,Condition,Observation,CarePlan,Task,QuestionnaireResponse,Immunization"
+
+  numThreads: 4
+  autoGenerateFlinkConfiguration: true
+  fhirVersion: "R4"
+  structureDefinitionsPath: "classpath:/r4-us-core-definitions"
+  rowGroupSizeForParquetFiles: 33554432
+
+  createHiveResourceTables: false
+  viewDefinitionsDir: "config/views"
+  createParquetViews: false
+  sinkDbConfigPath: "config/postgres-analytics.json"
+
+  recursiveDepth: 1
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info,metrics,prometheus,pipeline-metrics

--- a/data-pipes/config/postgres-analytics.json.example
+++ b/data-pipes/config/postgres-analytics.json.example
@@ -1,0 +1,9 @@
+{
+  "jdbcDriverClass": "org.postgresql.Driver",
+  "databaseService": "postgresql",
+  "databaseHostName": "postgres-analytics",
+  "databasePort": "5432",
+  "databaseUser": "postgres",
+  "databasePassword": "${POSTGRES_ADMIN_PASSWORD}",
+  "databaseName": "analytics"
+}

--- a/data-pipes/config/views/care_plan_flat_view.json
+++ b/data-pipes/config/views/care_plan_flat_view.json
@@ -1,0 +1,42 @@
+{
+  "resourceType": "http://hl7.org/fhir/uv/sql-on-fhir/StructureDefinition/ViewDefinition",
+  "text": "CarePlan flat view — program enrollment records; title = program name (HIV, ANC, etc.); addresses = enrollment condition",
+  "name": "care_plan_flat",
+  "status": "draft",
+  "resource": "CarePlan",
+  "fhirVersion": ["4.0"],
+  "select": [
+    {
+      "column": [
+        {"path": "getResourceKey()",                                                                          "name": "id"},
+        {"path": "subject.getReferenceKey(Patient)",                                                          "name": "patient_id"},
+        {"path": "encounter.getReferenceKey(Encounter)",                                                      "name": "encounter_id"},
+        {"path": "status",                                                                                    "name": "status"},
+        {"path": "intent",                                                                                    "name": "intent"},
+        {"path": "title",                                                                                     "name": "title"},
+        {"path": "period.start",                                                                              "name": "period_start",    "type": "dateTime"},
+        {"path": "period.end",                                                                                "name": "period_end",      "type": "dateTime"},
+        {"path": "author.getReferenceKey(Practitioner)",                                                      "name": "author_practitioner_id"},
+        {"path": "meta.lastUpdated",                                                                          "name": "last_updated",    "type": "dateTime"},
+        {"path": "meta.tag.where(system='https://smartregister.org/location-tag-id').code.first()",          "name": "location_tag_id"},
+        {"path": "meta.tag.where(system='https://smartregister.org/practitioner-tag-id').code.first()",      "name": "practitioner_tag_id"},
+        {"path": "meta.tag.where(system='https://smartregister.org/organisation-tag-id').code.first()",      "name": "org_tag_id"},
+        {"path": "meta.tag.where(system='https://smartregister.org/care-team-tag-id').code.first()",         "name": "care_team_tag_id"}
+      ]
+    },
+    {
+      "forEachOrNull": "addresses",
+      "column": [
+        {"path": "getReferenceKey(Condition)", "name": "condition_id"}
+      ]
+    },
+    {
+      "forEachOrNull": "category.coding",
+      "column": [
+        {"path": "system",  "name": "category_sys"},
+        {"path": "code",    "name": "category_code"},
+        {"path": "display", "name": "category_display"}
+      ]
+    }
+  ]
+}

--- a/data-pipes/config/views/condition_flat_view.json
+++ b/data-pipes/config/views/condition_flat_view.json
@@ -1,0 +1,51 @@
+{
+  "resourceType": "http://hl7.org/fhir/uv/sql-on-fhir/StructureDefinition/ViewDefinition",
+  "text": "Condition flat view — includes code.text (program name), recorded date, and smartregister.org meta tags",
+  "name": "condition_flat",
+  "status": "draft",
+  "resource": "Condition",
+  "fhirVersion": ["4.0"],
+  "select": [
+    {
+      "column": [
+        {"path": "getResourceKey()",                                                                          "name": "id"},
+        {"path": "subject.getReferenceKey(Patient)",                                                          "name": "patient_id"},
+        {"path": "encounter.getReferenceKey(Encounter)",                                                      "name": "encounter_id"},
+        {"path": "onset.ofType(dateTime)",                                                                    "name": "onset_datetime",  "type": "dateTime"},
+        {"path": "recordedDate",                                                                              "name": "recorded_date",   "type": "dateTime"},
+        {"path": "code.text",                                                                                 "name": "code_text"},
+        {"path": "meta.lastUpdated",                                                                          "name": "last_updated",    "type": "dateTime"},
+        {"path": "meta.tag.where(system='https://smartregister.org/location-tag-id').code.first()",          "name": "location_tag_id"},
+        {"path": "meta.tag.where(system='https://smartregister.org/practitioner-tag-id').code.first()",      "name": "practitioner_tag_id"},
+        {"path": "meta.tag.where(system='https://smartregister.org/organisation-tag-id').code.first()",      "name": "org_tag_id"},
+        {"path": "meta.tag.where(system='https://smartregister.org/care-team-tag-id').code.first()",         "name": "care_team_tag_id"}
+      ]
+    },
+    {
+      "forEachOrNull": "code.coding",
+      "column": [
+        {"path": "code",    "name": "code_code"},
+        {"path": "system",  "name": "code_sys"},
+        {"path": "display", "name": "code_display"}
+      ]
+    },
+    {
+      "forEachOrNull": "category.coding",
+      "column": [
+        {"path": "code", "name": "category"}
+      ]
+    },
+    {
+      "forEachOrNull": "clinicalStatus.coding",
+      "column": [
+        {"path": "code", "name": "clinical_status"}
+      ]
+    },
+    {
+      "forEachOrNull": "verificationStatus.coding",
+      "column": [
+        {"path": "code", "name": "verification_status"}
+      ]
+    }
+  ]
+}

--- a/data-pipes/config/views/diagnostic_report_flat_view.json
+++ b/data-pipes/config/views/diagnostic_report_flat_view.json
@@ -1,0 +1,97 @@
+{
+  "resourceType": "http://hl7.org/fhir/uv/sql-on-fhir/StructureDefinition/ViewDefinition",
+  "text": "This is the SQL-on-FHIR-v2 version of DiagnosticReport_flat.sql",
+  "fhirVersion": [
+    "4.0"
+  ],
+  "select": [
+    {
+      "column": [
+        {
+          "path": "getResourceKey()",
+          "name": "id"
+        },
+        {
+          "path": "subject.getReferenceKey(Patient)",
+          "name": "patient_id"
+        },
+        {
+          "path": "encounter.getReferenceKey(Encounter)",
+          "name": "encounter_id"
+        },
+        {
+          "path": "status",
+          "name": "status"
+        },
+        {
+          "path": "conclusion",
+          "name": "conclusion"
+        }
+      ]
+    },
+    {
+      "forEachOrNull": "code.coding",
+      "column": [
+        {
+          "path": "code",
+          "name": "code_code"
+        },
+        {
+          "path": "system",
+          "name": "code_sys"
+        },
+        {
+          "path": "display",
+          "name": "code_display"
+        }
+      ]
+    },
+    {
+      "forEachOrNull": "result",
+      "column": [
+        {
+          "path": "getReferenceKey(Observation)",
+          "name": "result_obs_id"
+        }
+      ]
+    },
+    {
+      "forEachOrNull": "category.coding",
+      "column": [
+        {
+          "path": "code",
+          "name": "category_code"
+        },
+        {
+          "path": "system",
+          "name": "category_sys"
+        }
+      ]
+    },
+    {
+      "forEachOrNull": "conclusion.coding",
+      "column": [
+        {
+          "path": "code",
+          "name": "conclusion_code"
+        },
+        {
+          "path": "system",
+          "name": "conclusion_sys"
+        }
+      ]
+    },
+    {
+      "forEachOrNull": "performer",
+      "column": [
+        {
+          "path": "getReferenceKey(Practitioner)",
+          "name": "practitioner_id"
+        }
+      ]
+    }
+  ],
+  "name": "diagnostic_report_flat",
+  "status": "draft",
+  "resource": "DiagnosticReport"
+}

--- a/data-pipes/config/views/encounter_flat_view.json
+++ b/data-pipes/config/views/encounter_flat_view.json
@@ -1,0 +1,47 @@
+{
+  "resourceType": "http://hl7.org/fhir/uv/sql-on-fhir/StructureDefinition/ViewDefinition",
+  "text": "Encounter flat view — includes class.code (HH visits), typed period dates, and smartregister.org meta tags",
+  "name": "encounter_flat",
+  "status": "draft",
+  "resource": "Encounter",
+  "fhirVersion": ["4.0"],
+  "select": [
+    {
+      "column": [
+        {"path": "getResourceKey()",                                                                          "name": "id"},
+        {"path": "status",                                                                                    "name": "status"},
+        {"path": "class.code",                                                                                "name": "encounter_class"},
+        {"path": "subject.getReferenceKey(Patient)",                                                          "name": "patient_id"},
+        {"path": "serviceProvider.getReferenceKey(Organization)",                                             "name": "service_org_id"},
+        {"path": "period.start",                                                                              "name": "period_start",     "type": "dateTime"},
+        {"path": "period.end",                                                                                "name": "period_end",       "type": "dateTime"},
+        {"path": "episodeOfCare.getReferenceKey(EpisodeOfCare)",                                              "name": "episode_of_care_id"},
+        {"path": "meta.lastUpdated",                                                                          "name": "last_updated",     "type": "dateTime"},
+        {"path": "meta.tag.where(system='https://smartregister.org/location-tag-id').code.first()",          "name": "location_tag_id"},
+        {"path": "meta.tag.where(system='https://smartregister.org/practitioner-tag-id').code.first()",      "name": "practitioner_tag_id"},
+        {"path": "meta.tag.where(system='https://smartregister.org/organisation-tag-id').code.first()",      "name": "org_tag_id"},
+        {"path": "meta.tag.where(system='https://smartregister.org/care-team-tag-id').code.first()",         "name": "care_team_tag_id"}
+      ]
+    },
+    {
+      "forEachOrNull": "type.coding",
+      "column": [
+        {"path": "system",  "name": "type_sys"},
+        {"path": "code",    "name": "type_code"},
+        {"path": "display", "name": "type_display"}
+      ]
+    },
+    {
+      "forEachOrNull": "participant",
+      "column": [
+        {"path": "individual.getReferenceKey(Practitioner)", "name": "practitioner_id"}
+      ]
+    },
+    {
+      "forEachOrNull": "location",
+      "column": [
+        {"path": "location.getReferenceKey(Location)", "name": "location_id"}
+      ]
+    }
+  ]
+}

--- a/data-pipes/config/views/group_flat_view.json
+++ b/data-pipes/config/views/group_flat_view.json
@@ -1,0 +1,39 @@
+{
+  "resourceType": "http://hl7.org/fhir/uv/sql-on-fhir/StructureDefinition/ViewDefinition",
+  "text": "Group (household) flat view — one row per household with village from hh_location characteristic; member expansion for household roster",
+  "name": "group_flat",
+  "status": "draft",
+  "resource": "Group",
+  "fhirVersion": ["4.0"],
+  "select": [
+    {
+      "column": [
+        {"path": "getResourceKey()",                                                                                                         "name": "id"},
+        {"path": "name",                                                                                                                     "name": "name"},
+        {"path": "active",                                                                                                                   "name": "active",            "type": "boolean"},
+        {"path": "type",                                                                                                                     "name": "type"},
+        {"path": "quantity",                                                                                                                 "name": "quantity",          "type": "integer"},
+        {"path": "managingEntity.getReferenceKey(Organization)",                                                                             "name": "managing_org_id"},
+        {"path": "characteristic.where(code.coding.where(code='hh_location').exists()).value.ofType(string).first()",                        "name": "village"},
+        {"path": "meta.lastUpdated",                                                                                                         "name": "last_updated",      "type": "dateTime"},
+        {"path": "meta.tag.where(system='https://smartregister.org/location-tag-id').code.first()",                                          "name": "location_tag_id"},
+        {"path": "meta.tag.where(system='https://smartregister.org/practitioner-tag-id').code.first()",                                      "name": "practitioner_tag_id"},
+        {"path": "meta.tag.where(system='https://smartregister.org/organisation-tag-id').code.first()",                                      "name": "org_tag_id"},
+        {"path": "meta.tag.where(system='https://smartregister.org/care-team-tag-id').code.first()",                                         "name": "care_team_tag_id"}
+      ]
+    },
+    {
+      "forEachOrNull": "identifier",
+      "column": [
+        {"path": "use",   "name": "identifier_use"},
+        {"path": "value", "name": "identifier_value"}
+      ]
+    },
+    {
+      "forEachOrNull": "member",
+      "column": [
+        {"path": "entity.getReferenceKey(Patient)", "name": "member_patient_id"}
+      ]
+    }
+  ]
+}

--- a/data-pipes/config/views/immunization_flat_view.json
+++ b/data-pipes/config/views/immunization_flat_view.json
@@ -1,0 +1,50 @@
+{
+  "resourceType": "http://hl7.org/fhir/uv/sql-on-fhir/StructureDefinition/ViewDefinition",
+  "text": "Immunization flat view — includes occurrence date, vaccine short name, and smartregister.org meta tags",
+  "name": "immunization_flat",
+  "status": "draft",
+  "resource": "Immunization",
+  "fhirVersion": ["4.0"],
+  "select": [
+    {
+      "column": [
+        {"path": "getResourceKey()",                                                                          "name": "id"},
+        {"path": "patient.getReferenceKey(Patient)",                                                          "name": "patient_id"},
+        {"path": "encounter.getReferenceKey(Encounter)",                                                      "name": "encounter_id"},
+        {"path": "status",                                                                                    "name": "status"},
+        {"path": "occurrence.ofType(dateTime)",                                                               "name": "occurrence_date", "type": "dateTime"},
+        {"path": "primarySource",                                                                             "name": "primary_source",  "type": "boolean"},
+        {"path": "vaccineCode.text",                                                                          "name": "vaccine_short_name"},
+        {"path": "location.getReferenceKey(Location)",                                                        "name": "location_id"},
+        {"path": "meta.lastUpdated",                                                                          "name": "last_updated",    "type": "dateTime"},
+        {"path": "meta.tag.where(system='https://smartregister.org/location-tag-id').code.first()",          "name": "location_tag_id"},
+        {"path": "meta.tag.where(system='https://smartregister.org/practitioner-tag-id').code.first()",      "name": "practitioner_tag_id"},
+        {"path": "meta.tag.where(system='https://smartregister.org/organisation-tag-id').code.first()",      "name": "org_tag_id"},
+        {"path": "meta.tag.where(system='https://smartregister.org/care-team-tag-id').code.first()",         "name": "care_team_tag_id"}
+      ]
+    },
+    {
+      "forEachOrNull": "vaccineCode.coding",
+      "column": [
+        {"path": "system",  "name": "vaccine_code_sys"},
+        {"path": "code",    "name": "vaccine_code"},
+        {"path": "display", "name": "vaccine_display"}
+      ]
+    },
+    {
+      "forEachOrNull": "statusReason.coding",
+      "column": [
+        {"path": "system",  "name": "status_reason_sys"},
+        {"path": "code",    "name": "status_reason_code"},
+        {"path": "display", "name": "status_reason_display"}
+      ]
+    },
+    {
+      "forEachOrNull": "performer",
+      "column": [
+        {"path": "actor.getReferenceKey(Practitioner)", "name": "practitioner_id"},
+        {"path": "actor.getReferenceKey(Organization)", "name": "organization_id"}
+      ]
+    }
+  ]
+}

--- a/data-pipes/config/views/location_flat_view.json
+++ b/data-pipes/config/views/location_flat_view.json
@@ -1,0 +1,37 @@
+{
+  "resourceType": "http://hl7.org/fhir/uv/sql-on-fhir/StructureDefinition/ViewDefinition",
+  "text": "Location flat view — includes partOf for hierarchy traversal and physicalType for jdn filtering",
+  "name": "location_flat",
+  "status": "draft",
+  "resource": "Location",
+  "fhirVersion": ["4.0"],
+  "select": [
+    {
+      "column": [
+        {"path": "getResourceKey()",                          "name": "id"},
+        {"path": "status",                                    "name": "status"},
+        {"path": "name",                                      "name": "name"},
+        {"path": "partOf.getReferenceKey(Location)",          "name": "parent_location_id"},
+        {"path": "managingOrganization.getReferenceKey(Organization)", "name": "org_id"},
+        {"path": "address.city",                              "name": "city"},
+        {"path": "address.country",                           "name": "country"},
+        {"path": "position.longitude",                        "name": "longitude"},
+        {"path": "position.latitude",                         "name": "latitude"}
+      ]
+    },
+    {
+      "forEachOrNull": "physicalType.coding",
+      "column": [
+        {"path": "code",    "name": "physical_type_code"},
+        {"path": "display", "name": "physical_type_display"}
+      ]
+    },
+    {
+      "forEachOrNull": "identifier",
+      "column": [
+        {"path": "use",   "name": "identifier_use"},
+        {"path": "value", "name": "identifier_value"}
+      ]
+    }
+  ]
+}

--- a/data-pipes/config/views/medication_request_flat_view.json
+++ b/data-pipes/config/views/medication_request_flat_view.json
@@ -1,0 +1,87 @@
+{
+  "resourceType": "http://hl7.org/fhir/uv/sql-on-fhir/StructureDefinition/ViewDefinition",
+  "text": "This is the SQL-on-FHIR-v2 version of MedicationRequest_flat.sql",
+  "fhirVersion": [
+    "4.0"
+  ],
+  "select": [
+    {
+      "column": [
+        {
+          "path": "getResourceKey()",
+          "name": "id"
+        },
+        {
+          "path": "subject.getReferenceKey(Patient)",
+          "name": "patient_id"
+        },
+        {
+          "path": "encounter.getReferenceKey(Encounter)",
+          "name": "encounter_id"
+        },
+        {
+          "path": "status",
+          "name": "status"
+        },
+        {
+          "path": "intent",
+          "name": "intent"
+        },
+        {
+          "path": "doNotPerform",
+          "name": "doNotPerform",
+          "type": "boolean"
+        },
+        {
+          "path": "requester.getReferenceKey(Practitioner)",
+          "name": "req_practitioner_id"
+        },
+        {
+          "path": "performer.getReferenceKey(Practitioner)",
+          "name": "perf_practitioner_id"
+        },
+        {
+          "path": "medication.ofType(Reference).getReferenceKey(Medication)",
+          "name": "med_id"
+        }
+      ]
+    },
+    {
+      "forEachOrNull": "medication.ofType(CodeableConcept).coding",
+      "column": [
+        {
+          "path": "system",
+          "name": "medication_system"
+        },
+        {
+          "path": "code",
+          "name": "medication_code"
+        },
+        {
+          "path": "display",
+          "name": "medication_display"
+        }
+      ]
+    },
+    {
+      "forEachOrNull": "statusReason.coding",
+      "column": [
+        {
+          "path": "system",
+          "name": "statusReason_sys"
+        },
+        {
+          "path": "code",
+          "name": "statusReason_code"
+        },
+        {
+          "path": "display",
+          "name": "statusReason_display"
+        }
+      ]
+    }
+  ],
+  "name": "medication_request_flat",
+  "status": "draft",
+  "resource": "MedicationRequest"
+}

--- a/data-pipes/config/views/observation_flat_view.json
+++ b/data-pipes/config/views/observation_flat_view.json
@@ -1,0 +1,51 @@
+{
+  "resourceType": "http://hl7.org/fhir/uv/sql-on-fhir/StructureDefinition/ViewDefinition",
+  "text": "Observation flat view — includes valueString (common in eCHIS), and smartregister.org meta tags",
+  "name": "observation_flat",
+  "status": "draft",
+  "resource": "Observation",
+  "fhirVersion": ["4.0"],
+  "select": [
+    {
+      "column": [
+        {"path": "getResourceKey()",                                                                          "name": "id"},
+        {"path": "subject.getReferenceKey(Patient)",                                                          "name": "patient_id"},
+        {"path": "encounter.getReferenceKey(Encounter)",                                                      "name": "encounter_id"},
+        {"path": "status",                                                                                    "name": "status"},
+        {"path": "effective.ofType(dateTime)",                                                                "name": "obs_date",        "type": "dateTime"},
+        {"path": "value.ofType(string)",                                                                      "name": "val_string"},
+        {"path": "value.ofType(Quantity).value",                                                              "name": "val_quantity",    "type": "decimal"},
+        {"path": "value.ofType(Quantity).unit",                                                               "name": "val_quantity_unit"},
+        {"path": "value.ofType(Quantity).system",                                                             "name": "val_quantity_system"},
+        {"path": "value.ofType(Quantity).code",                                                               "name": "val_quantity_code"},
+        {"path": "meta.lastUpdated",                                                                          "name": "last_updated",    "type": "dateTime"},
+        {"path": "meta.tag.where(system='https://smartregister.org/location-tag-id').code.first()",          "name": "location_tag_id"},
+        {"path": "meta.tag.where(system='https://smartregister.org/practitioner-tag-id').code.first()",      "name": "practitioner_tag_id"},
+        {"path": "meta.tag.where(system='https://smartregister.org/organisation-tag-id').code.first()",      "name": "org_tag_id"},
+        {"path": "meta.tag.where(system='https://smartregister.org/care-team-tag-id').code.first()",         "name": "care_team_tag_id"}
+      ]
+    },
+    {
+      "forEachOrNull": "code.coding",
+      "column": [
+        {"path": "code",    "name": "code_code"},
+        {"path": "system",  "name": "code_sys"},
+        {"path": "display", "name": "code_display"}
+      ]
+    },
+    {
+      "forEachOrNull": "value.ofType(CodeableConcept).coding",
+      "column": [
+        {"path": "code",    "name": "value_code"},
+        {"path": "system",  "name": "value_sys"},
+        {"path": "display", "name": "value_display"}
+      ]
+    },
+    {
+      "forEachOrNull": "performer",
+      "column": [
+        {"path": "getReferenceKey(Practitioner)", "name": "performer_practitioner_id"}
+      ]
+    }
+  ]
+}

--- a/data-pipes/config/views/organization_flat_view.json
+++ b/data-pipes/config/views/organization_flat_view.json
@@ -1,0 +1,63 @@
+{
+  "resourceType": "http://hl7.org/fhir/uv/sql-on-fhir/StructureDefinition/ViewDefinition",
+  "text": "This is the SQL-on-FHIR-v2 version of Organization_flat.sql",
+  "fhirVersion": [
+    "4.0"
+  ],
+  "select": [
+    {
+      "column": [
+        {
+          "path": "getResourceKey()",
+          "name": "id"
+        },
+        {
+          "path": "active",
+          "name": "active",
+          "type": "boolean"
+        },
+        {
+          "path": "name",
+          "name": "name"
+        },
+        {
+          "path": "partOf.getReferenceKey(Organization)",
+          "name": "partOf_org_id"
+        }
+      ]
+    },
+    {
+      "forEachOrNull": "address",
+      "column": [
+        {
+          "path": "city",
+          "name": "city"
+        },
+        {
+          "path": "country",
+          "name": "country"
+        }
+      ]
+    },
+    {
+      "forEachOrNull": "type.coding",
+      "column": [
+        {
+          "path": "system",
+          "name": "type_sys"
+        },
+        {
+          "path": "code",
+          "name": "type_code"
+        },
+        {
+          "path": "display",
+          "name": "type_display"
+        }
+      ]
+    }
+  ],
+  "name": "organization_flat",
+  "status": "draft",
+  "resource": "Organization"
+}

--- a/data-pipes/config/views/patient_flat_view.json
+++ b/data-pipes/config/views/patient_flat_view.json
@@ -1,0 +1,54 @@
+{
+  "resourceType": "http://hl7.org/fhir/uv/sql-on-fhir/StructureDefinition/ViewDefinition",
+  "text": "Patient flat view — includes smartregister.org meta tags for location-based reporting",
+  "name": "patient_flat",
+  "status": "draft",
+  "resource": "Patient",
+  "fhirVersion": ["4.0"],
+  "select": [
+    {
+      "column": [
+        {"path": "getResourceKey()",                                                                          "name": "id"},
+        {"path": "active",                                                                                    "name": "active",           "type": "boolean"},
+        {"path": "gender",                                                                                    "name": "gender"},
+        {"path": "birthDate",                                                                                 "name": "birth_date",       "type": "date"},
+        {"path": "deceased.ofType(boolean)",                                                                  "name": "is_deceased",      "type": "boolean"},
+        {"path": "deceased.ofType(dateTime)",                                                                 "name": "deceased_time",    "type": "dateTime"},
+        {"path": "managingOrganization.getReferenceKey(Organization)",                                        "name": "organization_id"},
+        {"path": "meta.lastUpdated",                                                                          "name": "last_updated",     "type": "dateTime"},
+        {"path": "meta.tag.where(system='https://smartregister.org/location-tag-id').code.first()",          "name": "location_tag_id"},
+        {"path": "meta.tag.where(system='https://smartregister.org/practitioner-tag-id').code.first()",      "name": "practitioner_tag_id"},
+        {"path": "meta.tag.where(system='https://smartregister.org/organisation-tag-id').code.first()",      "name": "org_tag_id"},
+        {"path": "meta.tag.where(system='https://smartregister.org/care-team-tag-id').code.first()",         "name": "care_team_tag_id"}
+      ]
+    },
+    {
+      "forEachOrNull": "generalPractitioner",
+      "column": [
+        {"path": "getReferenceKey(Practitioner)", "name": "practitioner_id"}
+      ]
+    },
+    {
+      "forEachOrNull": "name",
+      "column": [
+        {"path": "family", "name": "family"}
+      ],
+      "select": [
+        {
+          "forEachOrNull": "given",
+          "column": [
+            {"path": "$this", "name": "given"}
+          ]
+        }
+      ]
+    },
+    {
+      "forEachOrNull": "identifier",
+      "column": [
+        {"path": "use",    "name": "identifier_use"},
+        {"path": "value",  "name": "identifier_value"},
+        {"path": "system", "name": "identifier_sys"}
+      ]
+    }
+  ]
+}

--- a/data-pipes/config/views/practitioner_flat_view.json
+++ b/data-pipes/config/views/practitioner_flat_view.json
@@ -1,0 +1,39 @@
+{
+  "resourceType": "http://hl7.org/fhir/uv/sql-on-fhir/StructureDefinition/ViewDefinition",
+  "text": "Practitioner flat view — includes phone contact (eCHIS uses email system for phone numbers)",
+  "name": "practitioner_flat",
+  "status": "draft",
+  "resource": "Practitioner",
+  "fhirVersion": ["4.0"],
+  "select": [
+    {
+      "column": [
+        {"path": "getResourceKey()",                "name": "id"},
+        {"path": "active",                          "name": "active",  "type": "boolean"},
+        {"path": "gender",                          "name": "gender"},
+        {"path": "telecom.where(system='email').value.first()", "name": "phone"}
+      ]
+    },
+    {
+      "forEachOrNull": "name",
+      "column": [
+        {"path": "family", "name": "family"}
+      ],
+      "select": [
+        {
+          "forEachOrNull": "given",
+          "column": [
+            {"path": "$this", "name": "given"}
+          ]
+        }
+      ]
+    },
+    {
+      "forEachOrNull": "identifier",
+      "column": [
+        {"path": "use",   "name": "identifier_use"},
+        {"path": "value", "name": "identifier_value"}
+      ]
+    }
+  ]
+}

--- a/data-pipes/config/views/practitioner_role_flat_view.json
+++ b/data-pipes/config/views/practitioner_role_flat_view.json
@@ -1,0 +1,85 @@
+{
+  "resourceType": "http://hl7.org/fhir/uv/sql-on-fhir/StructureDefinition/ViewDefinition",
+  "text": "This is the SQL-on-FHIR-v2 version of PractitionerRole_flat.sql",
+  "fhirVersion": [
+    "4.0"
+  ],
+  "select": [
+    {
+      "column": [
+        {
+          "path": "getResourceKey()",
+          "name": "id"
+        },
+        {
+          "path": "active",
+          "name": "active",
+          "type": "boolean"
+        },
+        {
+          "path": "practitioner.getReferenceKey(Practitioner)",
+          "name": "practitioner_id"
+        },
+        {
+          "path": "organization.getReferenceKey(Organization)",
+          "name": "organization_id"
+        }
+      ]
+    },
+    {
+      "forEachOrNull": "code.coding",
+      "column": [
+        {
+          "path": "system",
+          "name": "code_sys"
+        },
+        {
+          "path": "code",
+          "name": "code_code"
+        },
+        {
+          "path": "display",
+          "name": "code_display"
+        }
+      ]
+    },
+    {
+      "forEachOrNull": "specialty.coding",
+      "column": [
+        {
+          "path": "system",
+          "name": "specialty_sys"
+        },
+        {
+          "path": "code",
+          "name": "specialty_code"
+        },
+        {
+          "path": "display",
+          "name": "specialty_display"
+        }
+      ]
+    },
+    {
+      "forEachOrNull": "location",
+      "column": [
+        {
+          "path": "getReferenceKey(Location)",
+          "name": "location_id"
+        }
+      ]
+    },
+    {
+      "forEachOrNull": "healthcareService",
+      "column": [
+        {
+          "path": "getReferenceKey(HealthcareService)",
+          "name": "healthcare_service_id"
+        }
+      ]
+    }
+  ],
+  "name": "practitioner_role_flat",
+  "status": "draft",
+  "resource": "PractitionerRole"
+}

--- a/data-pipes/config/views/procedure_flat_view.json
+++ b/data-pipes/config/views/procedure_flat_view.json
@@ -1,0 +1,72 @@
+{
+  "resourceType": "http://hl7.org/fhir/uv/sql-on-fhir/StructureDefinition/ViewDefinition",
+  "text": "This is [almost] the SQL-on-FHIR-v2 version of Procedure_flat.sql",
+  "fhirVersion": [
+    "4.0"
+  ],
+  "select": [
+    {
+      "column": [
+        {
+          "path": "getResourceKey()",
+          "name": "id"
+        },
+        {
+          "path": "subject.getReferenceKey(Patient)",
+          "name": "patient_id"
+        },
+        {
+          "path": "encounter.getReferenceKey(Encounter)",
+          "name": "encounter_id"
+        },
+        {
+          "path": "performer.actor.getReferenceKey(Practitioner)",
+          "name": "practitioner_id"
+        },
+        {
+          "path": "location.getReferenceKey(Location)",
+          "name": "location_id"
+        },
+        {
+          "path": "status",
+          "name": "status"
+        },
+        {
+          "path": "performed.ofType(Period).start",
+          "name": "period_start",
+          "type": "dateTime"
+        },
+        {
+          "path": "performed.ofType(Period).end",
+          "name": "period_end",
+          "type": "dateTime"
+        },
+        {
+          "path": "performed.ofType(dateTime)",
+          "name": "performed_time",
+          "type": "dateTime"
+        }
+      ]
+    },
+    {
+      "forEachOrNull": "code.coding",
+      "column": [
+        {
+          "path": "code",
+          "name": "code_code"
+        },
+        {
+          "path": "system",
+          "name": "code_sys"
+        },
+        {
+          "path": "display",
+          "name": "code_display"
+        }
+      ]
+    }
+  ],
+  "name": "procedure_flat",
+  "status": "draft",
+  "resource": "Procedure"
+}

--- a/data-pipes/config/views/related_person_flat_view.json
+++ b/data-pipes/config/views/related_person_flat_view.json
@@ -1,0 +1,49 @@
+{
+  "resourceType": "http://hl7.org/fhir/uv/sql-on-fhir/StructureDefinition/ViewDefinition",
+  "text": "RelatedPerson flat view — household composition; join to Patient via patient_id for family-level reporting",
+  "name": "related_person_flat",
+  "status": "draft",
+  "resource": "RelatedPerson",
+  "fhirVersion": ["4.0"],
+  "select": [
+    {
+      "column": [
+        {"path": "getResourceKey()",                 "name": "id"},
+        {"path": "patient.getReferenceKey(Patient)", "name": "patient_id"},
+        {"path": "active",                           "name": "active",       "type": "boolean"},
+        {"path": "gender",                           "name": "gender"},
+        {"path": "birthDate",                        "name": "birth_date",   "type": "date"},
+        {"path": "meta.lastUpdated",                 "name": "last_updated", "type": "dateTime"}
+      ]
+    },
+    {
+      "forEachOrNull": "relationship.coding",
+      "column": [
+        {"path": "code",    "name": "relationship_code"},
+        {"path": "system",  "name": "relationship_sys"},
+        {"path": "display", "name": "relationship_display"}
+      ]
+    },
+    {
+      "forEachOrNull": "name",
+      "column": [
+        {"path": "family", "name": "family"}
+      ],
+      "select": [
+        {
+          "forEachOrNull": "given",
+          "column": [
+            {"path": "$this", "name": "given"}
+          ]
+        }
+      ]
+    },
+    {
+      "forEachOrNull": "identifier",
+      "column": [
+        {"path": "use",   "name": "identifier_use"},
+        {"path": "value", "name": "identifier_value"}
+      ]
+    }
+  ]
+}

--- a/data-pipes/config/views/task_flat_view.json
+++ b/data-pipes/config/views/task_flat_view.json
@@ -1,0 +1,41 @@
+{
+  "resourceType": "http://hl7.org/fhir/uv/sql-on-fhir/StructureDefinition/ViewDefinition",
+  "text": "Task flat view — CHW workload; one row per follow-up task; for = patient; basedOn = care plan; owner = responsible CHW",
+  "name": "task_flat",
+  "status": "draft",
+  "resource": "Task",
+  "fhirVersion": ["4.0"],
+  "select": [
+    {
+      "column": [
+        {"path": "getResourceKey()",                                                                          "name": "id"},
+        {"path": "status",                                                                                    "name": "status"},
+        {"path": "intent",                                                                                    "name": "intent"},
+        {"path": "description",                                                                               "name": "description"},
+        {"path": "for.getReferenceKey(Patient)",                                                              "name": "patient_id"},
+        {"path": "owner.getReferenceKey(Practitioner)",                                                       "name": "owner_practitioner_id"},
+        {"path": "authoredOn",                                                                                "name": "authored_on",     "type": "dateTime"},
+        {"path": "lastModified",                                                                              "name": "last_modified",   "type": "dateTime"},
+        {"path": "meta.lastUpdated",                                                                          "name": "last_updated",    "type": "dateTime"},
+        {"path": "meta.tag.where(system='https://smartregister.org/location-tag-id').code.first()",          "name": "location_tag_id"},
+        {"path": "meta.tag.where(system='https://smartregister.org/practitioner-tag-id').code.first()",      "name": "practitioner_tag_id"},
+        {"path": "meta.tag.where(system='https://smartregister.org/organisation-tag-id').code.first()",      "name": "org_tag_id"},
+        {"path": "meta.tag.where(system='https://smartregister.org/care-team-tag-id').code.first()",         "name": "care_team_tag_id"}
+      ]
+    },
+    {
+      "forEachOrNull": "basedOn",
+      "column": [
+        {"path": "getReferenceKey(CarePlan)", "name": "care_plan_id"}
+      ]
+    },
+    {
+      "forEachOrNull": "code.coding",
+      "column": [
+        {"path": "system",  "name": "code_sys"},
+        {"path": "code",    "name": "code_code"},
+        {"path": "display", "name": "code_display"}
+      ]
+    }
+  ]
+}

--- a/data-pipes/postgres-init.sql
+++ b/data-pipes/postgres-init.sql
@@ -1,0 +1,6 @@
+-- Analytics PostgreSQL initialisation
+-- The default 'postgres' database is created automatically by POSTGRES_DB.
+-- This script creates the analytics and Superset databases.
+
+CREATE DATABASE analytics;
+CREATE DATABASE superset;

--- a/dev.sh
+++ b/dev.sh
@@ -108,6 +108,10 @@ render_templates() {
            hapi-fhir/application-auth.yaml \
            '${HAPI_FHIR_DB_PASSWORD} ${HAPI_FHIR_SERVER_KEYCLOAK_CLIENT_SECRET}'
 
+    render data-pipes/config/postgres-analytics.json.example \
+           data-pipes/config/postgres-analytics.json \
+           '${POSTGRES_ADMIN_PASSWORD}'
+
     compile_healthcheck
 }
 
@@ -148,8 +152,9 @@ parse_profiles() {
         case "$arg" in
             --web)   PROFILE_ARGS+=(--profile web)   ;;
             --pipes) PROFILE_ARGS+=(--profile pipes) ;;
+            --synth) PROFILE_ARGS+=(--profile synth) ;;
             --full)  PROFILE_ARGS+=(--profile full)  ;;
-            *)       error "Unknown flag: $arg (expected --web, --pipes, or --full)" ;;
+            *)       error "Unknown flag: $arg (expected --web, --pipes, --synth, or --full)" ;;
         esac
     done
 }
@@ -170,14 +175,14 @@ cmd_up() {
 cmd_down() {
     check_prerequisites
     info "Stopping stack..."
-    compose --profile web --profile pipes --profile full down
+    compose --profile web --profile pipes --profile synth --profile full down
 }
 
 cmd_reset() {
     check_prerequisites
     warn "This will stop all services and delete named volumes (postgres data will be lost)."
     info "Stopping stack and removing volumes..."
-    compose --profile web --profile pipes --profile full down --volumes
+    compose --profile web --profile pipes --profile synth --profile full down --volumes
     info "Reset complete. Run './dev.sh up' to start fresh."
 }
 
@@ -201,6 +206,7 @@ cmd_clean() {
     rm -f "$SCRIPT_DIR/keycloak/ohs-player-realm.json"
     rm -f "$SCRIPT_DIR/hapi-fhir/application-no-auth.yaml"
     rm -f "$SCRIPT_DIR/hapi-fhir/application-auth.yaml"
+    rm -f "$SCRIPT_DIR/data-pipes/config/postgres-analytics.json"
     info "Cleaned. Run './dev.sh render' to regenerate configs, or './dev.sh up' to regenerate and start services."
 }
 
@@ -210,8 +216,10 @@ usage() {
 Usage: $0 <command> [options]
 
 Commands:
-  up [--web|--pipes|--full]   Render configs and start services
+  up [--web|--pipes|--synth|--full]   Render configs and start services
                                 (no flag = core only)
+                                --synth  adds synthetic HAPI + postgres
+                                --pipes  adds synth + analytics pipeline + Superset
   down                        Stop all running services
   reset                       Stop services and wipe named volumes
   logs [service]              Tail logs (all services or one)

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -155,25 +155,153 @@ services:
   #   networks: [fhir_net]
 
   # ---------------------------------------------------------------------------
-  # data-pipes (extension service, profile: pipes / full)
+  # synth stack (profile: synth / pipes / full)
   #
-  # Stub — not yet wired up. Before enabling, the following still need to be
-  # decided and filled in:
-  #   - Image coordinates (registry + tag).
-  #   - Required env vars: FHIR source URL, sink configuration (database or
-  #     object store), pipeline schedule/mode.
-  #   - Volume mounts for pipeline config files, if any.
-  #   - Dependency order relative to hapi-fhir.
+  # Isolated HAPI FHIR + PostgreSQL for synthetic/test data generation.
+  # Kept separate from the transactional instance (ohs-hapi-fhir) so test
+  # data never touches production records.
+  # Also included in the pipes profile so the pipeline has a FHIR source.
+  #
+  # FHIR endpoint:  http://localhost:${HAPI_SYNTH_PORT:-8085}/fhir
+  # Postgres:       localhost:${POSTGRES_SYNTH_PORT:-5435}
+  #
+  # Load synthetic data:
+  #   python ohs-player-analytics/test-data/generate.py \
+  #     --fhir-url http://localhost:${HAPI_SYNTH_PORT:-8085}/fhir
   # ---------------------------------------------------------------------------
-  # data-pipes:
-  #   profiles: ["pipes", "full"]
-  #   image: TBD
-  #   container_name: ohs-data-pipes
-  #   restart: unless-stopped
-  #   depends_on:
-  #     hapi-fhir:
-  #       condition: service_started
-  #   networks: [fhir_net]
+  postgres-synth:
+    profiles: ["synth", "pipes", "full"]
+    image: postgres:18
+    container_name: ohs-postgres-synth
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: ${POSTGRES_ADMIN_PASSWORD}
+      POSTGRES_DB: hapi_fhir
+    volumes:
+      - postgres_synth_data:/var/lib/postgresql
+    ports:
+      - "127.0.0.1:${POSTGRES_SYNTH_PORT:-5435}:5432"
+    networks: [fhir_net]
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+
+  hapi-synth:
+    profiles: ["synth", "pipes", "full"]
+    image: hapiproject/hapi:v8.8.0-1
+    container_name: ohs-hapi-synth
+    restart: unless-stopped
+    depends_on:
+      postgres-synth:
+        condition: service_healthy
+    ports:
+      - "${HAPI_SYNTH_PORT:-8085}:8080"
+    environment:
+      - hapi.fhir.mdm_enabled=false
+      - hapi.fhir.bulk_export_enabled=true
+      - spring.datasource.url=jdbc:postgresql://postgres-synth:5432/hapi_fhir
+      - spring.datasource.username=postgres
+      - spring.datasource.password=${POSTGRES_ADMIN_PASSWORD}
+      - spring.datasource.driverClassName=org.postgresql.Driver
+      - spring.jpa.properties.hibernate.dialect=ca.uhn.fhir.jpa.model.dialect.HapiFhirPostgresDialect
+    volumes:
+      - ./hapi-fhir/health/Healthcheck.class:/healthcheck/Healthcheck.class:ro
+    networks: [fhir_net]
+    healthcheck:
+      test: ["CMD", "java", "-cp", "/healthcheck", "Healthcheck"]
+      interval: 30s
+      timeout: 10s
+      retries: 10
+      start_period: 180s
+
+  # ---------------------------------------------------------------------------
+  # analytics pipeline (profile: pipes / full)
+  #
+  # FHIR Data Pipes reads from hapi-synth, applies ViewDefinitions, and writes
+  # flat tables into postgres-analytics. Superset dashboards query those tables.
+  #
+  # Pipeline control panel: http://localhost:${PIPELINE_PORT:-8090}
+  # Superset:               http://localhost:${SUPERSET_PORT:-8088}  (admin/admin)
+  # Analytics Postgres:     localhost:${POSTGRES_ANALYTICS_PORT:-5434}
+  # ---------------------------------------------------------------------------
+  postgres-analytics:
+    profiles: ["pipes", "full"]
+    image: postgres:18
+    container_name: ohs-postgres-analytics
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: ${POSTGRES_ADMIN_PASSWORD}
+      POSTGRES_DB: postgres
+    volumes:
+      - postgres_analytics_data:/var/lib/postgresql
+      - ./data-pipes/postgres-init.sql:/docker-entrypoint-initdb.d/01-analytics-init.sql:ro
+    ports:
+      - "127.0.0.1:${POSTGRES_ANALYTICS_PORT:-5434}:5432"
+    networks: [fhir_net]
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+
+  pipeline-controller:
+    profiles: ["pipes", "full"]
+    image: us-docker.pkg.dev/cloud-build-fhir/fhir-analytics/main:latest
+    platform: linux/amd64
+    container_name: ohs-pipeline-controller
+    restart: unless-stopped
+    depends_on:
+      postgres-analytics:
+        condition: service_healthy
+      hapi-synth:
+        condition: service_healthy
+    ports:
+      - "${PIPELINE_PORT:-8090}:8080"
+    environment:
+      - JAVA_OPTS=${PIPELINE_JAVA_OPTS:--Xms512m -Xmx4g}
+      - FHIRDATA_FHIRSERVERURL=${PIPELINE_FHIR_SOURCE:-http://hapi-synth:8080/fhir}
+      - FHIRDATA_SINKDBCONFIGPATH=config/postgres-analytics.json
+    volumes:
+      - ./data-pipes/config:/app/config:ro
+      - ./data-pipes/dwh:/dwh
+    networks: [fhir_net]
+
+  superset:
+    profiles: ["pipes", "full"]
+    image: apache/superset:latest
+    container_name: ohs-superset
+    restart: unless-stopped
+    user: root
+    depends_on:
+      postgres-analytics:
+        condition: service_healthy
+    ports:
+      - "${SUPERSET_PORT:-8088}:8088"
+    environment:
+      - SUPERSET_SECRET_KEY=${SUPERSET_SECRET_KEY}
+      - SQLALCHEMY_DATABASE_URI=postgresql+psycopg2://postgres:${POSTGRES_ADMIN_PASSWORD}@postgres-analytics:5432/superset
+    volumes:
+      - superset_home:/app/superset_home
+    command:
+      - sh
+      - -c
+      - |
+        superset db upgrade &&
+        superset fab create-admin \
+          --username admin \
+          --firstname OHS \
+          --lastname Admin \
+          --email admin@ohs.local \
+          --password admin || true &&
+        superset init &&
+        gunicorn --bind 0.0.0.0:8088 --workers 2 --timeout 120 'superset.app:create_app()'
+    networks: [fhir_net]
 
 networks:
   fhir_net:
@@ -181,3 +309,6 @@ networks:
 
 volumes:
   postgres_data:
+  postgres_synth_data:
+  postgres_analytics_data:
+  superset_home:


### PR DESCRIPTION
Fixes #3 (Development Environment Docker Compose Extension Script: FHIR Data Pipes)

Adds an isolated synthetic data stack (ohs-hapi-synth + ohs-postgres-synth) and full analytics pipeline (FHIR Data Pipes + analytics PostgreSQL + Superset) as optional Docker Compose profiles. The synth HAPI runs on port 8085, separate from the transactional instance, so test data never touches production records. Start with ./dev.sh up --synth to load test data or ./dev.sh up --pipes for the full analytics stack including dashboards. Includes 16 SQL-on-FHIR ViewDefinitions for all OHS resource types.



## Analytics Pipeline — Synth Stack + FHIR Data Pipes + Superset

This PR adds the full analytics pipeline as opt-in Docker Compose profiles, alongside an isolated synthetic data HAPI FHIR instance for testing. Nothing in the core stack (postgres, keycloak, hapi-fhir, fhir-gateway) is changed.

---

### What was added

#### New Docker Compose profiles

Services are opted in via flags passed to `./dev.sh up`:

| Flag | Services started |
|---|---|
| _(none)_ | Core only — postgres, keycloak, hapi-fhir, fhir-gateway |
| `--synth` | Core + ohs-hapi-synth + ohs-postgres-synth |
| `--pipes` | Core + synth stack + pipeline-controller + postgres-analytics + superset |
| `--full` | All of the above + web-portal (stub, not yet wired) |

**Synth stack** (`--synth`):
- `ohs-hapi-synth` (port 8085) — isolated HAPI FHIR R4 instance for synthetic/test data. The mobile app and gateway never touch it.
- `ohs-postgres-synth` (port 5435) — dedicated PostgreSQL backing only hapi-synth.

**Analytics pipeline** (`--pipes`):
- `ohs-postgres-analytics` (port 5434) — PostgreSQL with two databases: `analytics` (flat tables written by the pipeline) and `superset` (Superset's own metadata).
- `ohs-pipeline-controller` (port 8090) — FHIR Data Pipes controller. Reads FHIR resources from hapi-synth, applies the 16 SQL-on-FHIR ViewDefinitions, and writes flat tables into the analytics database. Web control panel at http://localhost:8090.
- `ohs-superset` (port 8088) — Apache Superset for dashboards. Login: admin / admin.

---

#### New files

**`data-pipes/config/application.yaml`**
Pipeline controller configuration:
- `resourceList` — the 12 FHIR resource types the pipeline processes (Patient, Practitioner, Location, Group, RelatedPerson, Encounter, Condition, Observation, CarePlan, Task, QuestionnaireResponse, Immunization)
- `numThreads: 4` — limits Flink parallelism to avoid connection pool exhaustion against HAPI
- `viewDefinitionsDir: config/views` — where the pipeline looks for ViewDefinitions
- `sinkDbConfigPath: config/postgres-analytics.json` — database connection config (rendered from template)
- `incrementalSchedule` / `purgeSchedule` — nightly incremental sync at midnight, old snapshots purged at 00:30

**`data-pipes/config/postgres-analytics.json.example`**
Template for the analytics database connection. Rendered by `dev.sh` into `postgres-analytics.json` (gitignored) with `${POSTGRES_ADMIN_PASSWORD}` substituted from `.env`. Points to `ohs-postgres-analytics` on port 5432 (internal Docker network), database `analytics`.

**`data-pipes/config/views/` (16 files)**
SQL-on-FHIR v2 ViewDefinitions — JSON files that define how each FHIR resource is flattened into a relational table. The pipeline controller scans this directory automatically on startup.

| ViewDefinition | Output table | Key fields |
|---|---|---|
| `patient_flat_view.json` | `patient_flat` | demographics, meta.tag location/org/practitioner/care-team IDs |
| `practitioner_flat_view.json` | `practitioner_flat` | name, phone, identifier |
| `location_flat_view.json` | `location_flat` | name, type, parent_location_id (for hierarchy traversal) |
| `group_flat_view.json` | `group_flat` | household name, village, managing org, member patient IDs |
| `related_person_flat_view.json` | `related_person_flat` | relationship to patient, name, contact |
| `encounter_flat_view.json` | `encounter_flat` | class (HH visit filter), period, subject, meta.tags |
| `condition_flat_view.json` | `condition_flat` | code, program name (HIV/ANC etc.), recorded date, meta.tags |
| `observation_flat_view.json` | `observation_flat` | code, value (quantity/string/boolean), performer, meta.tags |
| `care_plan_flat_view.json` | `care_plan_flat` | program title, period, subject, author, addresses (conditions) |
| `task_flat_view.json` | `task_flat` | status, intent, owner, patient, based-on care plan, meta.tags |
| `immunization_flat_view.json` | `immunization_flat` | vaccine code, occurrence date, patient, meta.tags |
| `questionnaire_response_flat_view.json` | `questionnaire_response_flat` | subject, authored, source |
| `organization_flat_view.json` | `organization_flat` | name, type, identifier |
| `practitioner_role_flat_view.json` | `practitioner_role_flat` | practitioner, organization, location links |
| `diagnostic_report_flat_view.json` | `diagnostic_report_flat` | code, status, subject, effective date |
| `procedure_flat_view.json` | `procedure_flat` | code, status, subject, performed date |
| `medication_request_flat_view.json` | `medication_request_flat` | medication, status, subject, authored date |

All clinical ViewDefinitions extract the four `meta.tag` smartregister.org fields (`location-tag-id`, `organisation-tag-id`, `practitioner-tag-id`, `care-team-tag-id`) as join keys for location-based reporting.

**`data-pipes/postgres-init.sql`**
Runs on first boot of `ohs-postgres-analytics` to create the `analytics` and `superset` databases.

---

#### `.env.example` additions

```
POSTGRES_SYNTH_PORT=5435       # host port for ohs-postgres-synth
HAPI_SYNTH_PORT=8085           # host port for ohs-hapi-synth
POSTGRES_ANALYTICS_PORT=5434   # host port for ohs-postgres-analytics
PIPELINE_PORT=8090             # host port for pipeline controller
SUPERSET_PORT=8088             # host port for Superset
SUPERSET_SECRET_KEY=[generated]

# FHIR source for the pipeline — switch to hapi-fhir for transactional data
PIPELINE_FHIR_SOURCE=http://hapi-synth:8080/fhir
PIPELINE_JAVA_OPTS=-Xms512m -Xmx4g
```

---

### How to run

```bash
# 1. First-time setup
cp .env.example .env
./dev.sh up                     # start core services only

# 2. Load synthetic data
./dev.sh up --synth             # start isolated HAPI for test data
python ohs-player-analytics/test-data/generate.py \
  --fhir-url http://localhost:8085/fhir --patients 10000

# 3. Start the full analytics stack
./dev.sh up --pipes

# 4. Trigger a pipeline run
# → open http://localhost:8090 and click "Run"

# 5. Load indicator views (first time only)
psql -h localhost -p 5434 -U postgres -d analytics \
  < ohs-player-analytics/indicators/indicators.sql

# 6. Open Superset
# → http://localhost:8088  (admin / admin)
# → Add database connection: postgresql://postgres:<password>@localhost:5434/analytics
# → Build datasets and charts from the flat tables and indicator views
```

---

### Key decision point

`PIPELINE_FHIR_SOURCE` in `.env` defaults to `http://hapi-synth:8080/fhir` (synthetic data). When the platform is ready and the transactional HAPI has real CHW data, change this one line to `http://hapi-fhir:8080/fhir` and restart the pipeline — no other config changes needed.
